### PR TITLE
Fix test013: Pass test with correct output

### DIFF
--- a/tests/test013_func_tag.msgok
+++ b/tests/test013_func_tag.msgok
@@ -1,5 +1,5 @@
 
-Error detected while processing /home/dotxp/dev/VIM/vmustache/tests/test013_func_tag.vim:
-line    1:
-E484: Can't open file test013_script_tag.in
+faa
+i am a text with upper case
+I AM A TEXT WITH LOWER CASE
 

--- a/tests/test013_func_tag.vim
+++ b/tests/test013_func_tag.vim
@@ -1,4 +1,4 @@
-let text = join(readfile("test013_script_tag.in"), "\n")
+let text = join(readfile("test013_func_tag.in"), "\n")
 
 let tokens = vmustache#Tokenize(text)
 " echo "Tokenized:"


### PR DESCRIPTION
Before an error occured while running the test. The test still passed
because the error message was expected.

This removes the error and changes the expected output to the real
output.

I am not completely sure, if this is really how it should work, but it seems to make sense.
